### PR TITLE
🧼 rename setup to init

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A CLI for managing drafts, ideas, and notes.
 
 ## Usage
 
--   `-s --setup` set the destination directory for your notes
+-   `-i --init` initialize `nom`
 -   **WIP** `-c --create-draft <note-title>` will create a new draft and add it to the `.ideas` list
 -   **WIP** `-p --publish <note-title>` will publish the draft, remove it from the `.ideas` list, prompt for frontmatter
 -   **WIP** `-l --last-published` will interrogate the notes folder to find the latest `publish` date among the notes

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { Command } from "commander"
-import { createDraft } from "./createDraft"
-import { setup } from "./setup"
+import { init } from "./init"
 import dotenv from "dotenv"
 
 dotenv.config()
@@ -10,14 +9,14 @@ function main() {
     program.version("0.0.1", "-v --version", "Current Version")
 
     program
-        .command("setup")
-        .alias("s")
-        .description("Setup the manager")
+        .command("init")
+        .alias("i")
+        .description("Initialize nom, the hungry note manager")
         .option(
             "-t --target-dir <directoryPath>",
             "The relative path to the target directory for notes"
         )
-        .action(setup)
+        .action(init)
     program
         .command("create-draft <note-title>")
         .alias("c")

--- a/src/init.ts
+++ b/src/init.ts
@@ -6,11 +6,7 @@ const fsPromises = fs.promises
 import { prompt } from "inquirer"
 import { Config, HOME, NOTES_ROOT_DIR } from "./utils"
 
-interface SetupOptions {
-    targetDir?: string
-}
-
-export async function setup({ targetDir }: SetupOptions) {
+export async function init(targetDir?: string) {
     if (!targetDir) {
         const questions = [
             {
@@ -25,7 +21,6 @@ export async function setup({ targetDir }: SetupOptions) {
             (answers) => (targetDir = String(answers.targetDir))
         )
     }
-    console.log({ targetDir })
     const configurer = new NoteManagerConfigurer(targetDir)
     configurer.configure()
 }
@@ -89,7 +84,6 @@ class NoteManagerConfigurer extends Config {
         fsPromises
             .access(notePath)
             .then(() => {
-                console.log(`${notePath} exists`)
                 fsPromises
                     .access(`${notePath}/.notes.md`)
                     .then(() => `${notePath}/.notes.md exists`)
@@ -110,7 +104,6 @@ class NoteManagerConfigurer extends Config {
      * The `.notes.md` file is a catalogue of all notes
      */
     private initializeNotesCatalogue(path: string) {
-        console.log(`path --> `, { path })
         fs.writeFile(
             `${path}/.notes.md`,
             "# Drafts\n\n# Notes\n",


### PR DESCRIPTION
better communicates what this step does. also keeps it inline with
other clis, like git and npm.