### PR TITLE
✨ add count by tag/category

### DIFF
--- a/src/counts.ts
+++ b/src/counts.ts
@@ -1,12 +1,18 @@
 import chalk from "chalk"
 import { Command } from "commander"
-import { formatDt, Notes, Frontmatter } from "./utils"
+import { formatDt, Notes, Frontmatter, FrontmatterKeys } from "./utils"
 
-type Style = "date" | "publish" | "stage"
+type Style = keyof Frontmatter
 export function counters(args: Command) {
-    const { date, publish, stage } = args
-    console.log({ date, publish, stage })
+    const { category, date, publish, stage, tags } = args
+
     const styles: Style[] = []
+    if (category) {
+        styles.push("category")
+    }
+    if (tags) {
+        styles.push("tags")
+    }
     if (date) {
         styles.push("date")
     }
@@ -41,20 +47,43 @@ class CountNotes extends Notes {
         for (let [date, count] of this.counted) {
             console.log(`${date}: ${count}`)
         }
-        console.log(chalk.bold.blue(`Total: ${this.total}`))
+        console.log(chalk.bold.blue(`\nTotal note count: ${this.total}`))
         console.log(chalk.bold.blue(`^^^^^^^^^^^\n`))
     }
 
     async byStyle(style: Style) {
         this.counted = this.notes.reduce((acc, cur) => {
-            const val = style === "stage" ? cur[style] : formatDt(cur[style])
-            if (acc.has(val)) {
-                acc.set(val, acc.get(val) + 1)
+            const val = this.findVal(style, cur)
+            if (Array.isArray(val)) {
+                val.forEach((value) => {
+                    if (acc.has(value)) {
+                        acc.set(value, acc.get(value) + 1)
+                    } else {
+                        acc.set(value, 1)
+                    }
+                })
             } else {
-                acc.set(val, 1)
+                if (acc.has(val)) {
+                    acc.set(val, acc.get(val) + 1)
+                } else {
+                    acc.set(val, 1)
+                }
             }
+
             return acc
         }, new Map())
         this.print(style)
+    }
+    private findVal(
+        targetFrontmatter: keyof Frontmatter,
+        frontmatterObj: Frontmatter & { path: string }
+    ) {
+        if (
+            targetFrontmatter === FrontmatterKeys.date ||
+            targetFrontmatter === FrontmatterKeys.publish
+        ) {
+            return formatDt(frontmatterObj[targetFrontmatter])
+        }
+        return frontmatterObj[targetFrontmatter]
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,9 @@ function main() {
             "(Default) Return the count of notes listed by publish date"
         )
         .option("-s --stage", "Return the count of notes based on stage")
+        .option("-c --category", "Return the count of notes based on stage")
+        // .option("--filter", "filter out specific keys")
+        .option("-t --tags", "Return the count of notes based on stage")
         .action(counters)
     program
         .command("publish [note-title]")


### PR DESCRIPTION
Expands the Dates & Counts work in #16 

Now able to handle front matter that deals with arrays (e.g., `tags` and `category`)