### PR TITLE
🐛 fix nom update date bug [nom-47]

### DIFF
--- a/src/notes/noteHelpers.ts
+++ b/src/notes/noteHelpers.ts
@@ -8,7 +8,8 @@ import {
     ConfigurationKeys,
     DocumentStages,
     FrontmatterKeys,
-    validateDt,
+    isValidDt,
+    formatDt,
 } from "../utils"
 
 const fsPromises = fs.promises
@@ -37,8 +38,7 @@ export function generateFrontmatter(options: Map<FrontmatterKeys, any>) {
         }
         frontmatter += `\n`
     }
-    return `---\n${frontmatter}---
-    `
+    return `---\n${frontmatter}---\n`
 }
 
 export function readNote(path: string) {
@@ -77,16 +77,19 @@ export function parseOptions(
         FrontmatterKeys.stage,
         stage || DocumentStages.Draft
     )
+
     updateOptions(
         cliSetOptions,
         FrontmatterKeys.date,
-        (validateDt(date, defaultDateFormat) && date) || TODAY
+        (isValidDt(date) && formatDt(date)) || TODAY
     )
+
     updateOptions(
         cliSetOptions,
         FrontmatterKeys.publish,
-        (validateDt(publish, defaultDateFormat) && publish) || TODAY
+        (isValidDt(publish) && formatDt(publish)) || TODAY
     )
+
     updateOptions(cliSetOptions, FrontmatterKeys.private, privateKey || false)
     updateOptions(cliSetOptions, FrontmatterKeys.category, category)
     updateOptions(cliSetOptions, FrontmatterKeys.tags, tags)

--- a/src/utils/dateHelpers.ts
+++ b/src/utils/dateHelpers.ts
@@ -1,9 +1,9 @@
 import dayjs from "dayjs"
 
-export function validateDt(date: string, format: string = "YYYY-MM-DD") {
-    return dayjs(date, format).format(format) === date
+export function isValidDt(date: string) {
+    return dayjs(date).isValid()
 }
 
-export function formatDt(date: string, format: string = "YYYY-MM-DD") {
+export function formatDt(date: string, format?: string) {
     return dayjs(date).format(format)
 }


### PR DESCRIPTION
## Checklist

-   [x] The commit message are organized for human readability
-   [x] The branch has is appended with the issue, e.g., `branch-name-nom-32`
-   [x] Commit messages are appended with the issue number, e.g., `✨ short commit message [nom-32]`
-   [x] Commit messages follow our [convention](../README.md#Commit-Log-Standards).
-   [ ] ~Docs have been added / updated (for bug fixes / features)~
-   [ ] ~Tests for the changes have been added (for bug fixes / features)~

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

-   [ ] ✨ new feature
-   [x] 🐛 bug fix
-   [ ] 💅 style
-   [ ] 🧼 chore
-   [ ] 📝 docs
-   [ ] 🐎 performance
-   [ ] 🧪 tests
-   [ ] 🏗️ refactor
-   [ ] 🧰 tooling / infrastructure

## Which issue does this address?

fixes https://github.com/stephencweiss/note-mgr/issues/47

Simplify how dates are set within `nom` to basically just use the
default date format. this means that dates don't move around the
same way and validation is much more reliable. it _does_ mean that
typically dates should not be written manually, otherwise, it's
quite likely that the timezone will be off and the final date will be
off.

it's also possible that this will introduce a bug into the dates
command. But was unable to test as it's broken (see #19 )


## ✨Feature Only: What is the new behavior?

## Breaking Change?

-   Does this PR introduce a breaking change? No
-   What changes might users need to make in their application due to this PR? None

## Screenshots, recordings, other assets

## Other information
