### PR TITLE
✨ filter unpublished notes out [nom-53]

### DIFF
--- a/src/utils/noteDates.ts
+++ b/src/utils/noteDates.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk"
 import dayjs from "dayjs"
 import { Notes } from "./notes"
-import { IFrontmatter } from "./contentHelpers"
+import { DocumentStages, IFrontmatter } from "./contentHelpers"
 import { formatDt, isValidDt } from "./dateHelpers"
 import { generateErrorMessage } from "./errorMessages"
 
@@ -62,6 +62,7 @@ export class NoteDates extends Notes {
                 : await this.allNotesFrontmatter()
             this.printList = notes
                 .filter(this.filterBadDates)
+                .filter(this.filterUnpublishedNotes)
                 .filter(this.filterRecent.bind(this))
                 .sort(sortFn)
                 .map((note) => {
@@ -106,8 +107,12 @@ export class NoteDates extends Notes {
             : true
     }
 
-    private filterBadDates(frontmatter: IFrontmatter) {
-        return isValidDt(frontmatter.publish)
+    private filterBadDates(note: IFrontmatter) {
+        return isValidDt(note.publish)
+    }
+
+    private filterUnpublishedNotes(note: IFrontmatter) {
+        return note.stage === DocumentStages.Published
     }
 
     private pickSort(style: Published) {


### PR DESCRIPTION
when using the date filter, we now automatically strip out notes
that are not published.

## Checklist

-   [x] The commit message are organized for human readability
-   [x] The branch has is appended with the issue, e.g., `branch-name-nom-32`
-   [x] Commit messages are appended with the issue number, e.g., `✨ short commit message [nom-32]`
-   [x] Commit messages follow our [convention](../README.md#Commit-Log-Standards).
-   [x] Docs have been added / updated (for bug fixes / features)
-   [ ] Tests for the changes have been added (for bug fixes / features)

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

-   [x] ✨ new feature
-   [ ] 🐛 bug fix
-   [ ] 💅 style
-   [ ] 🧼 chore
-   [ ] 📝 docs
-   [ ] 🐎 performance
-   [ ] 🧪 tests
-   [ ] 🏗️ refactor
-   [ ] 🧰 tooling / infrastructure

## Which issue does this address?

closes https://github.com/stephencweiss/note-mgr/issues/53

## ✨Feature Only: What is the new behavior?

Now, instead of returning the latest publish date found in _any_ note, `nom d` more closely resembles the API description which suggests that we only care about published dates (and it stands to reason that only published notes will have published dates that are of concern during this process). 

## Breaking Change?

-   Does this PR introduce a breaking change? Y
-   What changes might users need to make in their application due to this PR?
This changes how the API behaves. No changes are necessary, just expectations of what is returned. 

## Screenshots, recordings, other assets

## Other information
